### PR TITLE
Quoted and unquoted interact behavior

### DIFF
--- a/interact.py
+++ b/interact.py
@@ -26,8 +26,8 @@ class InteractControl:
 class InputBox(InteractControl):
     def message(self):
         return {'control_type':'input_box',
-                'default':self.kwargs.get('default',None),
-                'raw':self.kwargs.get('raw',None),
+                'default':self.kwargs.get('default',""),
+                'raw':self.kwargs.get('raw',False),
                 'label':self.kwargs.get('label',"")}
     def default(self):
         return self.kwargs.get('default',None)
@@ -45,7 +45,7 @@ class Selector(InteractControl):
         return {'control_type': 'selector',
                 'values': self.values,
                 'default': self.default_value,
-                'raw': self.kwargs.get('raw',None),
+                'raw': self.kwargs.get('raw',False),
                 'label':self.kwargs.get('label',"")}
     def default(self):
         return self.values[self.default_value]
@@ -60,7 +60,7 @@ class Slider(InteractControl):
                 'default':self.kwargs.get('default',0),
                 'range':self.kwargs.get('range',[0,100]),
                 'step':self.kwargs.get('step',20),
-                'raw':self.kwargs.get('raw',1),
+                'raw':self.kwargs.get('raw',True),
                 'label':self.kwargs.get('label',"")}
     def default(self):
         return self.kwargs.get('default',0)

--- a/static/compute_server.js
+++ b/static/compute_server.js
@@ -353,10 +353,10 @@ InteractCell.prototype.bindChange = function(interact) {
             var changes = interact.getChanges();
             var code = interact.function_code + "(";
             for (var i in changes) {
-		if (interact.controls[i].raw == null) {
-		    code = code + i + "='" + changes[i].replace(/'/g, "\\'") + "',";
-		} else {
+		if (interact.controls[i].raw) {
 		    code = code + i + "=" + changes[i] + ",";
+		} else {
+		    code = code + i + "='" + changes[i].replace(/'/g, "\\'") + "',";
 		}
             }
             code = code + ")";


### PR DESCRIPTION
Creates "raw" field for interacts that defines whether or not new interact values should be returned as raw or quoted strings.
Default behavior: input_box: quoted to support spaces in values, selector: quoted to support spaces in values, slider: raw to support numerical commands (like print 2 \* <variable> in the interact function)
To manually set quoted values, the raw parameter should be: <interact>(raw = None); to manually set raw values, the raw parameter should be: <interact>(raw = <something python can interpret other than None, such as a number or string>)
