### PR TITLE
Rewriting the FileStoreMongo class to use the GridFS API more effectively

### DIFF
--- a/device_process.py
+++ b/device_process.py
@@ -414,7 +414,7 @@ Meant to be run as a separate process."""
                     file_list.append(filename)
                     try:
                         with open(filename) as f:
-                            fs.create_file(cell_id, filename, f)
+                            fs.create_file(f, cell_id=cell_id, filename=filename)
                     except Exception as e:
                         sys.stdout.write("An exception occurred: %s\n"%(e,))
             if len(file_list)>0:

--- a/web_server.py
+++ b/web_server.py
@@ -107,7 +107,7 @@ def output_long_poll(db,fs):
         sleep(poll_interval)
     return jsonify([])
 
-from flask import Response
+from flask import Response, abort
 import mimetypes
 @app.route("/files/<cell_id>/<filename>")
 @get_db
@@ -121,7 +121,11 @@ def cellFile(db,fs,cell_id,filename):
     mimetype=mimetypes.guess_type(filename)[0]
     if mimetype is None:
         mimetype = 'application/octet-stream'
-    return Response(fs.get_file(cell_id, filename), content_type=mimetype)
+    f=fs.get_file(cell_id=cell_id, filename=filename)
+    if f is not None:
+        return Response(f, content_type=mimetype)
+    else:
+        abort(404)
 
 @app.route("/complete")
 @get_db


### PR DESCRIPTION
Rewriting the FileStoreMongo class to use the GridFS API more effectively. NOW REQUIRES PyMongo 1.10.1 or higher (NOT the version in the Ubuntu repository). Fixes #40 and #43.
