### PR TITLE
Various javascript / html fixes relating to file uploading / single cell embedding

### DIFF
--- a/templates/body.html
+++ b/templates/body.html
@@ -5,7 +5,7 @@
   <input type="button" value="Add file" id="add_file">
   <input type="button" value="Clear files" id="clear_files">
   <div id = "file_upload"></div>
-</fielddset>
+</fieldset>
 <input type="hidden" value="" name="session_id" id="session_id">
 <input type="hidden" value="" name="msg_id" id="msg_id">
 <div id="completion"></div>

--- a/templates/root.html
+++ b/templates/root.html
@@ -17,7 +17,6 @@
       $(initPage);
     </script>
   </head>
-</script>
   <body>
     <div id="singlecell">
       {% include 'singlecell.html' %}

--- a/templates/singlecell.html
+++ b/templates/singlecell.html
@@ -1,13 +1,10 @@
 <textarea id="commands"></textarea><br />
-<fieldset id="file_input">
-  <legend>File Uploads</legend>
-  <input type="button" value="Add file" id="add_file">
-  <input type="button" value="Clear files" id="clear_files">
-  <div id="file_upload"></div>
+<fieldset style="width:100%; border:none" id="file_input">
+    <legend>Upload Files:</legend>
+    <input type="button" value="Add file" id="add_file">&nbsp;&nbsp;&nbsp;
+    <input type="button" value="Clear files" id="clear_files"><br />
+    <div id="file_upload"></div>
 </fieldset>
-<input type="hidden" value="" name="session_id" id="session_id">
-<input type="hidden" value="" name="msg_id" id="msg_id">
-<div id="completion"></div>
 <input type="button" value="Evaluate" id="eval_button">&nbsp;&nbsp;&nbsp;
 <input type="checkbox" checked="yes" id="sage_mode" name="sage_mode" value="True">
 Use &ldquo;Sage Mode&rdquo; for code execution<br />


### PR DESCRIPTION
Fixed file bugs that broke file uploading in Opera and prevented more than one file being uploaded in other browsers
Adds functionality to remove individual files from file upload, rather than being forced to clear them all
File upload selections are stored so the user can re-evaluate their input without doing additional work (the files do need to re-upload, however)

Minimizes the use of deep recursive copies with JQuery's clone() for performance
Removes unnecesary hidden html elements
Optimizes sage_mode session storage - only uses one try block now
Various html syntax fixes
