### PR TITLE
Kill trusted device cleanly

### DIFF
--- a/trusted_db.py
+++ b/trusted_db.py
@@ -202,6 +202,10 @@ def signal_handler(signal, frame):
     """
     Clean up device
     """
+    os.kill(db_loop.process.pid, 9)
+    os.wait()
+    os.kill(fs_loop.process.pid, 9)
+    os.wait()
     cleanup_device(device=db_loop.device_id(), pgid=db_loop.pgid())
     
 


### PR DESCRIPTION
This solves the problem of the trusted device process hanging even after pressing Ctrl+C several times, if the untrusted process has not been started or has exited with an error. It now exits after pressing Ctrl+C twice.
