### PR TITLE
Gh-214

### DIFF
--- a/device_process.py
+++ b/device_process.py
@@ -82,6 +82,9 @@ from sage.server.support import help
 from sagenb.misc.support import automatic_names
 sage.misc.session.init()
 
+# Ensure unique random state after forking
+set_random_seed()
+
 #try:
 #    attach(os.path.join(os.environ['DOT_SAGE'], 'init.sage'))
 #except (KeyError, IOError):


### PR DESCRIPTION
Refreshes Sage's random state after forking.

Python's random() appears to be safe after forking since random.random() has used OS resources since Python 2.4, so such a fix is unnecessary for non-Sage mode.

Test code: Execute the following multiple times

``` python
random()
```
