### PR TITLE
Shift+return code evaluation fix

### DIFF
--- a/templates/embedded_singlecell.js
+++ b/templates/embedded_singlecell.js
@@ -283,7 +283,7 @@ singlecell.renderEditor = (function(editor, inputLocation) {
 	    matchBrackets:true,
 	    readOnly: readOnly,
 	    onKeyEvent: (function(editor, event){
-		if (event.which === 13 && event.shiftKey && event.type === "keypress") {
+		if (event.keyCode === 13 && event.shiftKey && event.type === "keyup") {
 		    inputLocation.find(".singlecell_evalButton").click();
 		    event.stop();
 		    return true;


### PR DESCRIPTION
At least in newer versions of Google Chrome, CodeMirror's shift+eval doesn't work as is. This fixes it (and works in all browser's I've tested).
