### PR TITLE
Fixes session_end message printing

### DIFF
--- a/static/compute_server.js
+++ b/static/compute_server.js
@@ -279,7 +279,7 @@ singlecell.Session.prototype.get_output_success = function(data, textStatus, jqX
 		    this.replace_output = false;
 		    break;
 		case "session_end":
-		    if (! $.inArray(".singlecell_done", this.hideDynamic)) {
+		    if ($.inArray(".singlecell_done", this.hideDynamic) === -1) {
 			this.output("<div class='singlecell_done'>Session "+id+ " done</div>", output_block);
 		    }
 


### PR DESCRIPTION
This should solve the root cause behind the problem noted here:
https://groups.google.com/group/sage-devel/msg/48d517b2f5c2cb5c

Basically, the session_end message was being sent but not
displayed, so users would think that interacts were still active
when they were not.
