### PR TITLE
Be smarter about replacing session output

### DIFF
--- a/device_process.py
+++ b/device_process.py
@@ -409,6 +409,7 @@ def device(db, fs, workers, interact_timeout, keys, poll_interval=0.1, resource_
                  "header":{"msg_id":unicode(uuid.uuid4())},
                  "parent_header":sessions[session]['parent_header'],
                  "msg_type":"extension",
+                 "output_block":None,
                  "sequence":sequence[session]}
             new_messages.append(msg)
             del sequence[session]


### PR DESCRIPTION
Previously, interact output would not display properly if multiple messages were required to receive the output for a given interact update.

This fixes gh-239. It also makes the session_end message contain an output block, which fixes an inconsistency in the messaging system.
