### PR TITLE
unresponsive (from error?)

### DIFF
--- a/db_mongo.py
+++ b/db_mongo.py
@@ -156,8 +156,8 @@ class DB(db.DB):
                       "output_block": None,
                       "sequence": m["sequence"]})
         log("INSERTED: %s"%('\n'.join(str(m) for m in success),))
-       	if len(success) < len(messages):
-       		log("FAILED TO INSERT %d message(s)" % (len(messages) - len(success)))
+        if len(success) < len(messages):
+            log("FAILED TO INSERT %d message(s)" % (len(messages) - len(success)))
 
     def register_device(self, device, account, workers, pgid):
         """


### PR DESCRIPTION
aleph.sagemath.org is now unresponsive, and here is the last bit of the stdout log:

```
InvalidDocument: BSON document too large (21829064 bytes) - the connected server supports BSON document sizes up to 16777216 bytes.
ERROR:root:Exception in I/O handler for fd <zmq.core.socket.Socket object at 0xaa9a70>
Traceback (most recent call last):
  File "/padic/scratch/jason/sage-4.7.1-sage.math.washington.edu-x86_64-Linux/local/lib/python2.6/site-packages/zmq/eventloop/ioloop.py", line 330, in start
    self._handlers[fd](fd, events)
  File "/padic/scratch/jason/sage-4.7.1-sage.math.washington.edu-x86_64-Linux/local/lib/python2.6/site-packages/zmq/eventloop/zmqstream.py", line 391, in _handle_events
    self._handle_recv()
  File "/padic/scratch/jason/sage-4.7.1-sage.math.washington.edu-x86_64-Linux/local/lib/python2.6/site-packages/zmq/eventloop/zmqstream.py", line 424, in _handle_recv
    self._run_callback(callback, msg)
  File "/padic/scratch/jason/sage-4.7.1-sage.math.washington.edu-x86_64-Linux/local/lib/python2.6/site-packages/zmq/eventloop/zmqstream.py", line 365, in _run_callback
    callback(*args, **kwargs)
  File "trusted_db.py", line 95, in <lambda>
    stream.on_recv(lambda msgs:callback(db,key,pipe,fs_auth_dict if isFS else db_auth_dict,rep,msgs,isFS), copy=False)
  File "trusted_db.py", line 159, in callback
    db.add_messages([c[0] for c in content])
  File "/padic/scratch/jason/simple-python-db-compute/db_mongo.py", line 112, in add_messages
    self.database.messages.insert(messages)
  File "/padic/scratch/jason/sage-4.7.1-sage.math.washington.edu-x86_64-Linux/local/lib/python2.6/site-packages/pymongo/collection.py", line 310, in insert
    continue_on_error, self.__uuid_subtype), safe)
  File "/padic/scratch/jason/sage-4.7.1-sage.math.washington.edu-x86_64-Linux/local/lib/python2.6/site-packages/pymongo/connection.py", line 807, in _send_message
    (request_id, data) = self.__check_bson_size(message)
  File "/padic/scratch/jason/sage-4.7.1-sage.math.washington.edu-x86_64-Linux/local/lib/python2.6/site-packages/pymongo/connection.py", line 784, in __check_bson_size
    (max_doc_size, self.__max_bson_size))
InvalidDocument: BSON document too large (21829064 bytes) - the connected server supports BSON document sizes up to 16777216 bytes.
Traceback (most recent call last):
  File "device_process.py", line 793, in <module>
    keys=keys, resource_limits=resource_limits)
  File "device_process.py", line 343, in device
    for X in db.get_input_messages(device=device_id, limit=-1):
  File "/padic/scratch/jason/simple-python-db-compute/db_zmq.py", line 35, in f
    output=self.socket.recv_pyobj()
  File "socket.pyx", line 801, in zmq.core.socket.Socket.recv_pyobj (zmq/core/socket.c:7113)
cPickle.UnpicklingError: invalid load key, '{'.
```
