### PR TITLE
Overhaul permalinks

### DIFF
--- a/templates/embedded_sagecell.js
+++ b/templates/embedded_sagecell.js
@@ -335,10 +335,18 @@ sagecell.initCell = (function(sagecellInfo) {
             data["sage_mode"] = "on";
         }
         function callback(response) {
-            response = JSON.parse(response);
-            outputLocation.find(".sagecell_codeurl").attr("href", response.codeurl);
-            outputLocation.find(".sagecell_zipurl").attr("href", response.zipurl);
-            outputLocation.find(".sagecell_queryurl").attr("href", response.queryurl);
+            var response = JSON.parse(response);
+            var zipurl = outputLocation.find(".sagecell_zipurl");
+            var queryurl = outputLocation.find(".sagecell_queryurl");
+            if (response.zipurl.length < 1024) {
+                zipurl.attr("href", response.zipurl);
+                queryurl.css("padding-left", "1em");
+                zipurl.show();
+            } else {
+                queryurl.css("padding-left", "0");
+                zipurl.hide();
+            }
+            queryurl.attr("href", response.queryurl);
             new sagecell.Session(outputLocation, ".sagecell_output", response.session_id,
                     inputLocation.find(".sagecell_sageModeCheck").attr("checked"));
             outputLocation.find(".sagecell_computationID span").append(response.session_id);

--- a/templates/sagecell.html
+++ b/templates/sagecell.html
@@ -22,9 +22,8 @@
 </div>
 <div class="sagecell_output_elements">
   <div class="sagecell_permalinks">
-    <a class="sagecell_codeurl">Permalink</a>
-    (<a class="sagecell_zipurl">Alternative permalink</a>;
-    <a class="sagecell_queryurl">Shortened temporary link</a>)
+    <a class="sagecell_zipurl">Permalink</a>
+    <a class="sagecell_queryurl">Shortened temporary link</a>
   </div>
   <div class="sagecell_output"></div>
   <div class="sagecell_computationID">Computation ID: <span></span></div>

--- a/web_server.py
+++ b/web_server.py
@@ -150,13 +150,9 @@ def evaluate(db,fs):
         import zlib, base64
         z=base64.urlsafe_b64encode(zlib.compress(code.encode('utf8')))
         zipurl = url_for('root', _external=True, z=z)
-        if len(urlencode({'c': code.encode('utf8')}))<100:
-            codeurl = url_for('root', _external=True, c=code)
-        else:
-            codeurl=zipurl
         queryurl = url_for('root', _external=True, q=shortened)
-        rval = json.dumps({"codeurl": codeurl, "zipurl": zipurl,
-                           "queryurl": queryurl, "session_id": session_id})
+        rval = json.dumps({"zipurl": zipurl, "queryurl": queryurl,
+                           "session_id": session_id})
     if (request.values.get("frame") is not None):
         return Response("<script>parent.postMessage(" + json.dumps(rval) +
                 ",\"*\");</script>")
@@ -167,17 +163,6 @@ def evaluate(db,fs):
 
 from urllib import urlencode, urlopen
 from json import loads
-
-def GooGL(url):
-    # Note: we need to get an API key to do this legally
-    params = urlencode({'security_token': None, 'longURL': url})
-    f = urlopen('http://goo.gl/api/shorten', params)
-    return loads(f.read())['short_url']
-
-def tinyurl(url):
-    params = urlencode({'url':url})
-    f = urlopen('http://tinyurl.com/api-create.php', params)
-    return f.read()
 
 @app.route("/output_poll")
 @print_exception


### PR DESCRIPTION
Fixes gh-299. Removes codeurl and only shows zipurl if it is under the 1024 character limit. Also removes license-breaking web-based permalink api functions.
