### PR TITLE
advanced_installation.rst doesn't say how to configure the device to use untrusted accounts

### DIFF
--- a/doc/advanced_installation.rst
+++ b/doc/advanced_installation.rst
@@ -164,6 +164,9 @@ restrictions; this account will be executing arbitrary user code).
    :file:`{$SERVER}/sagecell/sagecell_config.py.default` and make the
    following changes:
 
+   * Change the value of ``untrusted-account`` from ``'localhost'`` to
+     :samp:`'{<UNTRUSTED_USER>}@localhost'`.
+
    * If you are using MongoDB, the ``mongo_uri`` variable should be set to
      :samp:`'mongodb://{<SAGECELL_USER>}:{<SAGECELL_PASSWORD}>@localhost:{<MONGODB_PORT>}'`
      and the ``db`` variable should be set to ``'mongo'``.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -224,4 +224,4 @@ intersphinx_mapping = {'python': ('http://docs.python.org/release/2.7.2/', None)
                        'pymongo': ('http://api.mongodb.org/python/current/', None),
                        'pyzmq': ('http://zeromq.github.com/pyzmq/', None),
                        'sqlalchemy': ('http://docs.sqlalchemy.org/en/rel_0_5/', None),
-                       'sage': ('http://www.sagemath.org/doc/reference/', None)}
+                       'sage': ('http://www.sagemath.org/doc/', None)}


### PR DESCRIPTION
(I wish I could directly make this comment or issue at the page for this file...)

In `advanced_installation.rst`, you say something about creating an untrusted account for the worker process, but don't say how to configure the device to use it. In `sagecell_config.py`, I see `'untrusted-account': 'localhost'`, but how do I tell it the account to use?

(I guessed, and it seems like "name@localhost" is what to use...but we should document it!)
