### PR TITLE
Fix failing tests

### DIFF
--- a/contrib/ipython-testing/tests/trusted_kernel_manager_tests.py
+++ b/contrib/ipython-testing/tests/trusted_kernel_manager_tests.py
@@ -169,10 +169,6 @@ class TestTrustedMultiKernelManager(object):
         for k in new_config:
             assert_equal(self.a._comps[x][k], new_config[k], "config value %s (%s) does not agree (should be %s)"%(k,self.a._comps[x][k], new_config[k]))
 
-        #TODO: the following two asserts don't pass...
-        assert_in("socket", self.a._clients[x])
-        assert_equal(self.a._clients[x]["socket"].socket_type, 3)
-
         assert_in("ssh", self.a._clients[x])
 
         assert_regexp_matches(out[0], self.executing_re)
@@ -264,13 +260,9 @@ class TestTrustedMultiKernelManager(object):
         x = self.a.add_computer(self.default_comp_config)
         kern1 = self.a.new_session()
 
-        with capture_output() as (out, err):
-            self.a.interrupt_kernel(kern1)
-        out = out[0]
+        reply = self.a.interrupt_kernel(kern1)
 
-        assert_in('interrupted', out)
-        assert_not_in('not', out)
-        #TODO: there should be a way of detecting if the kernel was interrupted without relying on stdout
+        assert_equal(reply["type"], "success")
 
     def test_new_session_success(self): # depends on add_computer
         x = self.a.add_computer(self.default_comp_config)

--- a/contrib/ipython-testing/trusted_kernel_manager.py
+++ b/contrib/ipython-testing/trusted_kernel_manager.py
@@ -179,7 +179,7 @@ class TrustedMultiKernelManager(object):
         :arg str kernel_id: the id of the kernel you want interrupted
         """
         comp_id = self._kernels[kernel_id]["comp_id"]
-        reply = self._sender.send_msg({"type": "interrupt_kerenl",
+        reply = self._sender.send_msg({"type": "interrupt_kernel",
                                        "content": {"kernel_id": kernel_id}},
                                       comp_id)
 
@@ -187,6 +187,7 @@ class TrustedMultiKernelManager(object):
             print "Kernel %s interrupted."%kernel_id
         else:
             print "Kernel %s not interrupted!"%kernel_id
+        return reply
 
     def new_session(self):
         """ Starts a new kernel on an open computer. 


### PR DESCRIPTION
test_add_computer_success was failing because we don't use a direct
socket to communicate with the untrusted side anymore, so it wasn't
stored in the expected location.

test_interrupt_kernel was failing because the message being sent to the
untrusted side had a spelling error in the message type.
