### PR TITLE
Defining variables in interact decorator defines in globals, not locals

### DIFF
--- a/contrib/ipython-testing/interact_sagecell.py
+++ b/contrib/ipython-testing/interact_sagecell.py
@@ -114,8 +114,7 @@ def interact_func(session, pub_socket):
         The decorator can be used in several ways::
 
             @interact([name1, (name2, control2), (name3, control3)])
-            def f(name1, **kwargs):
-                print name1, kwargs["name2"], kwargs["name3"]
+            def f(**kwargs):
                 ...
 
             @interact
@@ -147,19 +146,17 @@ def interact_func(session, pub_socket):
                 if isinstance(name, str):
                     controls[i]=(name, None)
                 elif not isinstance(name[0], str):
-                    raise ValueError("interact control must have a string name, but %s isn't a string"%(name[0],))
+                    raise ValueError("interact control must have a string name, but %r isn't a string"%(name[0],))
         names = {c[0] for c in controls}
 
         import inspect
         (args, varargs, varkw, defaults) = inspect.getargspec(f)
+        if len(names) != len(controls) or any(a in names for a in args):
+            raise ValueError("duplicate argument in interact definition")
         if defaults is None:
             defaults=[]
         n=len(args)-len(defaults)
-
-        arg_controls = zip(args, [None] * n + list(defaults))
-        arg_controls = [(k, v) for k, v in arg_controls if k not in names]
-        controls += arg_controls
-
+        controls = zip(args, [None] * n + list(defaults)) + controls
         names=[n for n,_ in controls]
         controls=[automatic_control(c, var=n) for n,c in controls]
         nameset = set(names)


### PR DESCRIPTION
See http://ask.sagemath.org/question/1647/sagecell-kwargs-no-longer-works for issues that this creates.

The following should have the same behavior, but it doesn't.

```
@interact
def f(n = ContinuousSlider()):
    print locals()
    print globals()["n"]


@interact(controls = [("n",ContinuousSlider())])
def f(**kwargs):
    print locals()
    print globals()["n"]
```

What seems to be the issue is that when defining interact controls in the interact decorator, we add those to the interacted function's global namespace, rather than in the local namespace (see the difference between `adapted_f()` in the previous version of `interact_sagecell.py` in comparison to the current version in `/contrib/ipython_testing`.).

I seem to remember that we talked about this potential issue briefly a while back, but I don't think it was ever resolved.
