### PR TITLE
Using a JQuery selector as inputLocation/outputLocation

### DIFF
--- a/contrib/ipython-testing/static/embedded_sagecell.js
+++ b/contrib/ipython-testing/static/embedded_sagecell.js
@@ -115,6 +115,16 @@ sagecell.makeSagecell = function (args) {
     if (args.inputLocation === undefined) {
         throw "Must specify an inputLocation!";
     }
+    var input = $(args.inputLocation);
+    if (input.length > 1 && args.outputLocation === undefined) {
+        var r = [];
+        for (var i = 0; i < input.length; i++) {
+            var a = $.extend({}, args);
+            a.inputLocation = input[i];
+            r.push(sagecell.makeSagecell(a));
+        }
+        return r;
+    }
     if (args.outputLocation === undefined) {
         args.outputLocation = args.inputLocation;
     }
@@ -207,6 +217,8 @@ sagecell.makeSagecell = function (args) {
                                 "out": {"output": true,       "messages": true,
                                         "sessionFiles": true, "permalink": true}};
                 var hidden_out = [];
+                var out_class = "output_" + IPython.utils.uuid();
+                outputLocation.addClass(out_class);
                 for (var i = 0, i_max = hide.length; i < i_max; i++) {
                     if (hide[i] in hideable["in"]) {
                         inputLocation.find(".sagecell_"+hide[i]).css("display", "none");
@@ -216,7 +228,7 @@ sagecell.makeSagecell = function (args) {
                             hideAdvanced[hide[i]] = true;
                         }
                     } else if (hide[i] in hideable["out"]) {
-                        hidden_out.push(settings.outputLocation + " .sagecell_" + hide[i]);
+                        hidden_out.push("." + out_class + " .sagecell_" + hide[i]);
                     }
                 }
                 if (hideAdvanced.files && hideAdvanced.sageMode) {

--- a/contrib/ipython-testing/static/sagecell.css
+++ b/contrib/ipython-testing/static/sagecell.css
@@ -69,6 +69,7 @@
 
 .sagecell_sessionContainer {
     position: relative;
+    margin-bottom: 10px;
 }
 
 .sagecell_sessionOutput {


### PR DESCRIPTION
This pull request will allow the embedder to use any object that can be used as a JQuery selector (a string, a DOM node, or another JQuery collection) as the `inputLocation` and `outputLocation` arguments to `makeSagecell`. The old behavior allowed only a string representing a CSS selector for a single location.

If the `inputLocation` selects multiple nodes, and `outputLocation` is not given, a separate Sage Cell will be created in each of the selected locations, as requested by @kcrisman [in this question](http://ask.sagemath.org/question/1564/sage-cell-server-do-i-really-need-so-many).
