### PR TITLE
Properly handle service requests with multiple stream messages

### DIFF
--- a/contrib/ipython-testing/handlers.py
+++ b/contrib/ipython-testing/handlers.py
@@ -462,7 +462,7 @@ class IOPubServiceHandler(IOPubHandler):
 
     def _output_message(self, msg):
         if msg["msg_type"] == "stream":
-             self.streams[msg["content"]["name"]] = msg["content"]["data"]
+            self.streams[msg["content"]["name"]] += msg["content"]["data"]
 
 class ShellWebHandler(ShellHandler, tornado.websocket.WebSocketHandler):
     def _output_message(self, message):


### PR DESCRIPTION
Previously, only the last stream message would have data stored in the
returned dictionary, replacing any previously-stored data.

For instance, this code:

```
http://aleph.sagemath.org/service?code=for%20i%20in%20xrange(10):%20print%20i
```

would only return:

```
{"success": true, "stdout": "9\n"}
```

when it should return:

```
{"success": true, "stdout": "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n"}
```
