### PR TITLE
Sphinx extension for sagecell

### DIFF
--- a/contrib/sagecellext.py
+++ b/contrib/sagecellext.py
@@ -8,7 +8,7 @@ Add the following lines to your layout.html file (e.g., in source/_templates)
 
 {%- block extrahead %}
     <script type="text/javascript" src="http://aleph.sagemath.org/static/jquery.min.js"></script>
-    <script type="text/javascript" src="http://aleph.sagemath.org/embedded_sagecell.js"></script>
+    <script type="text/javascript" src="http://aleph.sagemath.org/static/embedded_sagecell.js"></script>
     <style type="text/css">.sagecell_output th, .sagecell_output td {border: none;}</style>
 {% endblock %}
 


### PR DESCRIPTION
This is a sphinx extension that takes  an rst snippet like this one and converts it to a sagecell in html, thanks to the similar plugin for moinmoin wiki.

USAGE:

```
.. sagemath::

    1+1
    print "hello world"
```

https://gist.github.com/3768246 takes a slightly different approach which modifies highlighting.py in the Sphinx base code so it'll likely to break with a new sphinx release. 
It adds  a 'sagecell' language to the code-block or sourcecode directive's language options. sagecell is exactly equivalent to python except when html output is produced.  In the case of html output the 
regular Pygments highlighting + HTML output workflow is bypassed and it uses html_sagecell 
instead to produce a sagecell. 
