### PR TITLE
don't make a Sage cell if it has already been made

### DIFF
--- a/static/embedded_sagecell.js
+++ b/static/embedded_sagecell.js
@@ -228,6 +228,9 @@ sagecell.makeSagecell = function (args, k) {
 	// Wait for the page to load before trying to find various DOM elements
         $(function () {
             var input = $(args.inputLocation);
+            if (input.length === 0) {
+                return [];
+            }
             if (input.length > 1 && args.outputLocation === undefined) {
                 var r = [];
                 if (args.linked) {
@@ -239,6 +242,9 @@ sagecell.makeSagecell = function (args, k) {
                     r.push(sagecell.makeSagecell(a, k));
                 }
                 return r;
+            }
+            if (input.hasClass("sagecell")) {
+            	return null;
             }
             if (k === undefined) {
                 k = sagecell.kernels.push(null) - 1;


### PR DESCRIPTION
On https://plus.google.com/u/0/111272571205985168793/posts/5aM83AYhxgS, we're seeing a problem where makeSagecell is being called on the same div twice (I think that's what is happening).  The first time, the div is made into a Sage cell, and the second time, it takes the sage cell html as the default code!

We should be smarter when making a Sage cell and check first to see if we've already made the div into a cell.  A quick check would be just checking to see if the div already has the class "sagecell".
