### PR TITLE
Cell doesn't get loaded on IE8

### DIFF
--- a/static/embedded_sagecell.js
+++ b/static/embedded_sagecell.js
@@ -4,6 +4,11 @@ var undefined;
 
 // Make a global sagecell namespace for our functions
 window.sagecell = window.sagecell || {};
+if (!window.console) {
+    // IE8 does not have console object before activating Developer Tools
+    window.console = {"log": function () {}};
+    console.warn = console.log;
+}
 
 if (!document.head) {
     document.head = document.getElementsByTagName("head")[0];


### PR DESCRIPTION
Hi, I was checking how our website looks on IE8 and it seems that it doesn't show the sage cell. You can look at it yourself at http://devel.findstat.org/DyckPaths/ (will be replaced by www.findstat.org/DyckPaths/ the next hours/days).

In the header, we have

```
<script src="http://sagecell.sagemath.org/static/jquery.min.js"></script>
<script src="http://sagecell.sagemath.org/static/embedded_sagecell.js"></script>
<script>sagecell.makeSagecell({"inputLocation": "#sagecell"});</script>
```

and in the body

```
<div id="sagecell-a4e69a95-c918-46af-852e-97744ab591b5"><script type="text/x-sage">D = DyckWords(3)
for d in D:
    print d
    print d.area()

d = DyckWord([1,1,0,0,1,0,1,0])
print d.to_132_avoiding_permutation()</script></div>
<script type="text/javascript">
$(function () {
    sagecell.makeSagecell({inputLocation: '#sagecell-a4e69a95-c918-46af-852e-97744ab591b5'});
});
</script>
```

IE8 says

```
'console' is undefined
embedded_sagecell.js
```

Other browsers show it properly...
