### PR TITLE
msg_id and session missing in "execution_state": "dead" status

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -545,10 +545,17 @@ class IOPubHandler(ZMQStreamHandler):
             self.application.km.end_session(self.kernel_id)
         except:
             pass
-        msg = {'header': {'msg_type': 'status'},
-               'parent_header': {},
-               'metadata': {},
-               'content': {'execution_state':'dead'}}
+        msg = {
+            'header': {
+                'msg_type': 'status',
+                'session': self.kernel_id,
+                'msg_id': str(uuid.uuid4()),
+                'username': ''
+            },
+            'parent_header': {},
+            'metadata': {},
+            'content': {'execution_state': 'dead'}
+        }
         self._output_message(msg)
         self.on_close()
 


### PR DESCRIPTION
The final state doesn't include session
id or msg_id (https://github.com/sagemath/sagecell/wiki/Session):

{
    "content": {
        "execution_state": "dead"
    },
    "header": {
        "msg_type": "status"
    },
    "parent_header": {},
    "metadata": {}
}

It would make the whole protocol more uniform
if really all messages had the session and msg_id fields.
