### PR TITLE
Fix way to hide share button

### DIFF
--- a/doc/embedding.rst
+++ b/doc/embedding.rst
@@ -326,7 +326,7 @@ The following input elements can be hidden:
 
 The following output elements can be hidden:
 
-* Permalinks (``permalinks``)
+* Share button to permalinks (``permalink``)
 * Session output (``output``)
 * Session end message (``done``)
 * Session files (``sessionFiles``)


### PR DESCRIPTION
Apparently "permalink", not "permalinks", is what is required to hide to make the Share button disappear.  This isn't necessarily the final version of what would need to be done, but anyway a suggestion.
