### PR TITLE
Support user_expressions in service requests

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -401,6 +401,7 @@ accepted_tos=true\n""")
                 if msg["msg_type"] == "execute_reply":
                     self.success = msg["content"]["status"] == "ok"
                     self.user_variables = msg["content"].get("user_variables", [])
+                    self.user_expressions = msg["content"].get("user_expressions", {})
                     self.execute_reply = msg['content']
                     loop.remove_timeout(self.timeout_request)
                     loop.add_callback(self.finish_request)
@@ -415,7 +416,7 @@ accepted_tos=true\n""")
                             "content": {"code": code,
                                         "silent": False,
                                         "user_variables": self.get_arguments('user_variables'),
-                                        "user_expressions": {},
+                                        "user_expressions": jsonapi.loads(self.get_argument('user_expressions', default="{}")),
                                         "allow_stdin": False,
                                         },
                             "metadata": {}
@@ -437,6 +438,8 @@ accepted_tos=true\n""")
         retval.update(success=getattr(self, 'success', 'abort'))
         if hasattr(self, 'user_variables'):
             retval.update(user_variables=self.user_variables)
+        if hasattr(self, 'user_expressions'):
+            retval.update(user_expressions=self.user_expressions)
         if hasattr(self, 'execute_reply'):
             retval.update(execute_reply=self.execute_reply)
         self.set_header("Access-Control-Allow-Origin", self.request.headers.get("Origin", "*"))


### PR DESCRIPTION
I have not tested this (I don't have a current working test setup).  I *think* this should work.  A test would be something like:
```
curl -i -k -sS -L https://sagecell.sagemath.org/service --data-urlencode "accepted_tos=true" --data-urlencode "user_expressions={'myvar': '1+1'}" --data-urlencode "code=print 'hi'"
```
and check that the return value has a user_expressions field.