### PR TITLE
Delete redundant user_variables and user_expressions fields

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -400,8 +400,6 @@ accepted_tos=true\n""")
             def done(msg):
                 if msg["msg_type"] == "execute_reply":
                     self.success = msg["content"]["status"] == "ok"
-                    self.user_variables = msg["content"].get("user_variables", [])
-                    self.user_expressions = msg["content"].get("user_expressions", {})
                     self.execute_reply = msg['content']
                     loop.remove_timeout(self.timeout_request)
                     loop.add_callback(self.finish_request)
@@ -436,10 +434,6 @@ accepted_tos=true\n""")
         self.iopub_handler.on_close()
         # if the timeout is calling the finish_request, the success and other attributes may not be set
         retval.update(success=getattr(self, 'success', 'abort'))
-        if hasattr(self, 'user_variables'):
-            retval.update(user_variables=self.user_variables)
-        if hasattr(self, 'user_expressions'):
-            retval.update(user_expressions=self.user_expressions)
         if hasattr(self, 'execute_reply'):
             retval.update(execute_reply=self.execute_reply)
         self.set_header("Access-Control-Allow-Origin", self.request.headers.get("Origin", "*"))


### PR DESCRIPTION
Since the user_variables and user_expressions fields are already part of the execute_reply content, just leave them there and don’t duplicate the data.