### PR TITLE
Adjust iframe template for iOS

### DIFF
--- a/backend_cell.py
+++ b/backend_cell.py
@@ -129,7 +129,8 @@ class BackendCell(BackendIPython):
                              'application/x-jmol': path})
         elif isinstance(rich_output, OutputSceneThreejs):
             self.display_html("""
-                <iframe srcdoc="{}" scrolling="no"
+                <iframe
+                    srcdoc="{}" scrolling="no"
                     style="border: 0; height: 500px; min-width: 500px; width: 75%;">
                 </iframe>
                 """.format(rich_output.html.get().replace('"', '&quot;')))

--- a/backend_cell.py
+++ b/backend_cell.py
@@ -129,7 +129,7 @@ class BackendCell(BackendIPython):
                              'application/x-jmol': path})
         elif isinstance(rich_output, OutputSceneThreejs):
             self.display_html("""
-                <iframe srcdoc="{}"
+                <iframe srcdoc="{}" scrolling="no"
                     style="border: 0; height: 500px; min-width: 500px; width: 75%;">
                 </iframe>
                 """.format(rich_output.html.get().replace('"', '&quot;')))


### PR DESCRIPTION
@novoselt there is a known issue with iOS where an embedded iframe containing Three.js grows continuously. The official [fix](https://github.com/mrdoob/three.js/blob/dev/examples/index.html#L267) resets iframe width and height as well, but in my testing today that was unnecessary. Setting this attribute should solve the problem for iOS 10 without impacting other browsers, since the Three.js iframe won't need to scroll anyway.

I've identified a couple other issues that will need to be addressed. For Safari on both desktop and mobile, changing the `srcdoc` attribute does not refresh the iframe, but needs to have that done manually with a kludge like `iframe.srcdoc = iframe.srcdoc`. Is there some event that fires when the output cell appears in the document that could be used to trigger the refresh?

Also, the `srcdoc` attribute is not supported by Internet Explorer or Edge, but is under consideration for the latter. If we want to support Microsoft browsers right now, the HTML would need to be saved to disc and loaded into `src` instead. I don't consider this high priority since I don't use either browser seriously, but there it is.