### PR TITLE
Use src instead of srcdoc

### DIFF
--- a/backend_cell.py
+++ b/backend_cell.py
@@ -131,7 +131,7 @@ class BackendCell(BackendIPython):
             self.display_html("""
                 <iframe
                     scrolling="no"
-                    srcdoc="{}"
+                    src="{}"
                     style="
                         border: 1px silver solid;
                         height: 500px;
@@ -140,7 +140,7 @@ class BackendCell(BackendIPython):
                         "
                     >
                 </iframe>
-                """.format(rich_output.html.get().replace('"', '&quot;')))
+                """.format(rich_output.html.filename()))
             
         else:
             raise TypeError('rich_output type not supported, got {0}'.format(rich_output))


### PR DESCRIPTION
If you want to support IE and Edge, then this should be all that needs to change. The HTML is saved by the backend and should be available just like a JPG. Doesn't look like you need to specify the extension but not entirely sure.

This may also help with the caching issue in Safari where `iframe`s are blank on reload or in an interact.