### PR TITLE
Add sqlalchemy into pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ In particular, system packages installed in the base container are listed [here]
     sage/sage -pip install lockfile
     sage/sage -pip install paramiko
     sage/sage -pip install sockjs-tornado
+    sage/sage -pip install sqlalchemy
     ```
 
     Note that version 1.0.3 of `sockjs-tornado` has a CORS issue fixed by https://github.com/mrjoes/sockjs-tornado/pull/83 You may delete these lines manually from `sage/local/lib/python2.7/site-packages/sockjs/tornado/basehandler.py`


### PR DESCRIPTION
This error happen on Ubuntu 16.04

```
$ sage web_server.py -p 80

Building Maxima command completion list (this takes
a few seconds only the first time you do it).
To force rebuild later, delete /home/sage/.sage//maxima_commandlist_cache.sobj.
AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz
Done!

Building R command completion list (this takes
a few seconds only the first time you do it).
To force rebuild later, delete /home/sage/.sage//r_commandlist.sobj.
Traceback (most recent call last):
  File "web_server.py", line 153, in <module>
    app = SageCellServer(args.baseurl, args.dir)
  File "web_server.py", line 82, in __init__
    db = __import__('db_' + config.get('db'))
  File "/home/sage/sagecell/db_sqlalchemy.py", line 9, in <module>
    from sqlalchemy import create_engine, Column, Integer, String, DateTime
ImportError: No module named sqlalchemy
```