### PR TITLE
use jQuery.noConflict

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -8,6 +8,8 @@ define([
 "use strict";
 var undefined;
 
+$.noConflict(true)
+
 /* IPython url_join_encode and url_path_join is used in the cell server with URLs with hostnames, so we make it handle those correctly
     this is a temporary kludge.  A much better fix would be to introduce a kernel_base_url parameter in the kernel
     initialization, which would default to the empty string, and would be prepended to every kernel request.  Also, the


### PR DESCRIPTION
So the embedded sagecell doesn't overwrite any jQuery already in the
page.

fixes #521