### PR TITLE
Provide easy access to CodeMirror editor instance.

### DIFF
--- a/js/cell.js
+++ b/js/cell.js
@@ -235,6 +235,7 @@ function init(cellInfo, k) {
     var temp = editor.render(cellInfo.editor, input, cellInfo.collapse);
     var editorType = temp[0];
     var editorData = temp[1];
+    cellInfo.editorData = editorData;
     editorData.k = k;
     input.find(".sagecell_advancedTitle").on("click", function () {
         input.find(".sagecell_advancedFields").slideToggle();


### PR DESCRIPTION
By stashing a reference to the editorData in the cellInfo object, we can make it easy to use the CodeMirror API. E.g. this is useful if you want to programmatically update the contents of the editor pane.