### PR TITLE
Revert the configuration to MathJax2

### DIFF
--- a/js/cell.js
+++ b/js/cell.js
@@ -34,39 +34,71 @@ var fs = document.getElementsByTagName('script')[0];
 fs.parentNode.insertBefore(style, fs);
 
 if (window.MathJax === undefined) {
+    // MathJax 2
     var script = document.createElement("script");
-    script.type = "text/javascript";
-    script.text = `window.MathJax = {
-        tex: {
-          inlineMath: [["$", "$"], ["\\\\(", "\\\\)"]],
-          displayMath: [["$$", "$$"], ["\\\\[", "\\\\]"]],
-          processEscapes: true,
-          processEnvironments: true,
-          packages: {'[+]': ['color']}
+    script.type = "text/x-mathjax-config";
+    script.text = "MathJax.Hub.Config(" + JSON.stringify({
+        "extensions": ["jsMath2jax.js", "tex2jax.js"],
+        "tex2jax": {
+            "inlineMath": [["$", "$"], ["\\(", "\\)"]],
+            "displayMath": [["$$", "$$"], ["\\[", "\\]"]],
+            "processEscapes": true,
+            "processEnvironments": true
         },
-        loader: {
-          load: ['[tex]/color']
-        },
-        options: {
-          renderActions: { /* remove when dropping MathJax2 compatibility */
-            find_script_mathtex: [10, function (doc) {
-              for (const node of document.querySelectorAll('script[type^="math/tex"]')) {
-                const display = !!node.type.match(/; *mode=display/);
-                const math = new doc.options.MathItem(node.textContent, doc.inputJax[0], display);
-                const text = document.createTextNode('');
-                node.parentNode.replaceChild(text, node);
-                math.start = {node: text, delim: '', n: 0};
-                math.end = {node: text, delim: '', n: 0};
-                doc.math.push(math);
-              }
-            }, '']
-          }
+        "TeX": {
+            "extensions": ["color.js"]
         }
-    };`;
+    }) + ");";
+    fs.parentNode.insertBefore(script, fs);
+//    // MathJax 3
+//    script.type = "text/javascript";
+//    script.text = `window.MathJax = {
+//        tex: {
+//          inlineMath: [["$", "$"], ["\\\\(", "\\\\)"]],
+//          displayMath: [["$$", "$$"], ["\\\\[", "\\\\]"]],
+//          processEscapes: true,
+//          processEnvironments: true,
+//          packages: {'[+]': ['color']}
+//        },
+//        loader: {
+//          load: ['[tex]/color']
+//        },
+//        options: {
+//          renderActions: { /* remove when dropping MathJax2 compatibility */
+//            find_script_mathtex: [10, function (doc) {
+//              for (const node of document.querySelectorAll('script[type^="math/tex"]')) {
+//                const display = !!node.type.match(/; *mode=display/);
+//                const math = new doc.options.MathItem(node.textContent, doc.inputJax[0], display);
+//                const text = document.createTextNode('');
+//                node.parentNode.replaceChild(text, node);
+//                math.start = {node: text, delim: '', n: 0};
+//                math.end = {node: text, delim: '', n: 0};
+//                doc.math.push(math);
+//              }
+//            }, '']
+//          }
+//        }
+//    };`;
+//    script.type = "text/x-mathjax-config";
+//    script.text = "MathJax.Hub.Config(" + JSON.stringify({
+//        "extensions": ["jsMath2jax.js", "tex2jax.js"],
+//        "tex2jax": {
+//            "inlineMath": [["$", "$"], ["\\(", "\\)"]],
+//            "displayMath": [["$$", "$$"], ["\\[", "\\]"]],
+//            "processEscapes": true,
+//            "processEnvironments": true
+//        },
+//        "TeX": {
+//            "extensions": ["color.js"]
+//        }
+//    }) + ");";
     fs.parentNode.insertBefore(script, fs);
     script = document.createElement("script");
     script.type = "text/javascript";
-    script.src  = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js";
+    // MathJax 2
+    script.src  = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS-MML_HTMLorMML";
+    // MathJax 3
+    // script.src  = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js";
     fs.parentNode.insertBefore(script, fs);
 }
 // Preload images


### PR DESCRIPTION
Hi Andrey,

I don't know why MathJax 3 is initialized differently, sporadically. So I cannot fix the problem right away.

This is a hot fix to revert back the initial configuration  back to MathJax 2.

Note that the MathJax 3 configuration is not removed but commented out.
