### PR TITLE
Mathjax3 full

### DIFF
--- a/js/cell.js
+++ b/js/cell.js
@@ -34,51 +34,8 @@ var fs = document.getElementsByTagName('script')[0];
 fs.parentNode.insertBefore(style, fs);
 
 if (window.MathJax === undefined) {
-    // MathJax 2
-    var script = document.createElement("script");
-    script.type = "text/x-mathjax-config";
-    script.text = "MathJax.Hub.Config(" + JSON.stringify({
-        "extensions": ["jsMath2jax.js", "tex2jax.js"],
-        "tex2jax": {
-            "inlineMath": [["$", "$"], ["\\(", "\\)"]],
-            "displayMath": [["$$", "$$"], ["\\[", "\\]"]],
-            "processEscapes": true,
-            "processEnvironments": true
-        },
-        "TeX": {
-            "extensions": ["color.js"]
-        }
-    }) + ");";
-    fs.parentNode.insertBefore(script, fs);
-//    // MathJax 3
-//    script.type = "text/javascript";
-//    script.text = `window.MathJax = {
-//        tex: {
-//          inlineMath: [["$", "$"], ["\\\\(", "\\\\)"]],
-//          displayMath: [["$$", "$$"], ["\\\\[", "\\\\]"]],
-//          processEscapes: true,
-//          processEnvironments: true,
-//          packages: {'[+]': ['color']}
-//        },
-//        loader: {
-//          load: ['[tex]/color']
-//        },
-//        options: {
-//          renderActions: { /* remove when dropping MathJax2 compatibility */
-//            find_script_mathtex: [10, function (doc) {
-//              for (const node of document.querySelectorAll('script[type^="math/tex"]')) {
-//                const display = !!node.type.match(/; *mode=display/);
-//                const math = new doc.options.MathItem(node.textContent, doc.inputJax[0], display);
-//                const text = document.createTextNode('');
-//                node.parentNode.replaceChild(text, node);
-//                math.start = {node: text, delim: '', n: 0};
-//                math.end = {node: text, delim: '', n: 0};
-//                doc.math.push(math);
-//              }
-//            }, '']
-//          }
-//        }
-//    };`;
+//    // MathJax 2
+//    var script = document.createElement("script");
 //    script.type = "text/x-mathjax-config";
 //    script.text = "MathJax.Hub.Config(" + JSON.stringify({
 //        "extensions": ["jsMath2jax.js", "tex2jax.js"],
@@ -92,13 +49,41 @@ if (window.MathJax === undefined) {
 //            "extensions": ["color.js"]
 //        }
 //    }) + ");";
+//    fs.parentNode.insertBefore(script, fs);
+//    script = document.createElement("script");
+//    script.type = "text/javascript";
+//    script.src  = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS-MML_HTMLorMML";
+//    fs.parentNode.insertBefore(script, fs);
+    // MathJax 3
+    var script = document.createElement("script");
+    script.type = "text/javascript";
+    script.text = `window.MathJax = {
+        tex: {
+          inlineMath: [["$", "$"], ["\\\\(", "\\\\)"]],
+          displayMath: [["$$", "$$"], ["\\\\[", "\\\\]"]],
+          processEscapes: true,
+          processEnvironments: true,
+        },
+        options: {
+          renderActions: { /* remove when dropping MathJax2 compatibility */
+            find_script_mathtex: [10, function (doc) {
+              for (const node of document.querySelectorAll('script[type^="math/tex"]')) {
+                const display = !!node.type.match(/; *mode=display/);
+                const math = new doc.options.MathItem(node.textContent, doc.inputJax[0], display);
+                const text = document.createTextNode('');
+                node.parentNode.replaceChild(text, node);
+                math.start = {node: text, delim: '', n: 0};
+                math.end = {node: text, delim: '', n: 0};
+                doc.math.push(math);
+              }
+            }, '']
+          }
+        }
+    };`;
     fs.parentNode.insertBefore(script, fs);
     script = document.createElement("script");
     script.type = "text/javascript";
-    // MathJax 2
-    script.src  = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS-MML_HTMLorMML";
-    // MathJax 3
-    // script.src  = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js";
+    script.src  = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js";
     fs.parentNode.insertBefore(script, fs);
 }
 // Preload images

--- a/js/cell.js
+++ b/js/cell.js
@@ -34,39 +34,71 @@ var fs = document.getElementsByTagName('script')[0];
 fs.parentNode.insertBefore(style, fs);
 
 if (window.MathJax === undefined) {
+    // MathJax 2
     var script = document.createElement("script");
-    script.type = "text/javascript";
-    script.text = `window.MathJax = {
-        tex: {
-          inlineMath: [["$", "$"], ["\\\\(", "\\\\)"]],
-          displayMath: [["$$", "$$"], ["\\\\[", "\\\\]"]],
-          processEscapes: true,
-          processEnvironments: true,
-          packages: {'[+]': ['color']}
+    script.type = "text/x-mathjax-config";
+    script.text = "MathJax.Hub.Config(" + JSON.stringify({
+        "extensions": ["jsMath2jax.js", "tex2jax.js"],
+        "tex2jax": {
+            "inlineMath": [["$", "$"], ["\\(", "\\)"]],
+            "displayMath": [["$$", "$$"], ["\\[", "\\]"]],
+            "processEscapes": true,
+            "processEnvironments": true
         },
-        loader: {
-          load: ['[tex]/color']
-        },
-        options: {
-          renderActions: { /* remove when dropping MathJax2 compatibility */
-            find_script_mathtex: [10, function (doc) {
-              for (const node of document.querySelectorAll('script[type^="math/tex"]')) {
-                const display = !!node.type.match(/; *mode=display/);
-                const math = new doc.options.MathItem(node.textContent, doc.inputJax[0], display);
-                const text = document.createTextNode('');
-                node.parentNode.replaceChild(text, node);
-                math.start = {node: text, delim: '', n: 0};
-                math.end = {node: text, delim: '', n: 0};
-                doc.math.push(math);
-              }
-            }, '']
-          }
+        "TeX": {
+            "extensions": ["color.js"]
         }
-    };`;
+    }) + ");";
+    fs.parentNode.insertBefore(script, fs);
+//    // MathJax 3
+//    script.type = "text/javascript";
+//    script.text = `window.MathJax = {
+//        tex: {
+//          inlineMath: [["$", "$"], ["\\\\(", "\\\\)"]],
+//          displayMath: [["$$", "$$"], ["\\\\[", "\\\\]"]],
+//          processEscapes: true,
+//          processEnvironments: true,
+//          packages: {'[+]': ['color']}
+//        },
+//        loader: {
+//          load: ['[tex]/color']
+//        },
+//        options: {
+//          renderActions: { /* remove when dropping MathJax2 compatibility */
+//            find_script_mathtex: [10, function (doc) {
+//              for (const node of document.querySelectorAll('script[type^="math/tex"]')) {
+//                const display = !!node.type.match(/; *mode=display/);
+//                const math = new doc.options.MathItem(node.textContent, doc.inputJax[0], display);
+//                const text = document.createTextNode('');
+//                node.parentNode.replaceChild(text, node);
+//                math.start = {node: text, delim: '', n: 0};
+//                math.end = {node: text, delim: '', n: 0};
+//                doc.math.push(math);
+//              }
+//            }, '']
+//          }
+//        }
+//    };`;
+//    script.type = "text/x-mathjax-config";
+//    script.text = "MathJax.Hub.Config(" + JSON.stringify({
+//        "extensions": ["jsMath2jax.js", "tex2jax.js"],
+//        "tex2jax": {
+//            "inlineMath": [["$", "$"], ["\\(", "\\)"]],
+//            "displayMath": [["$$", "$$"], ["\\[", "\\]"]],
+//            "processEscapes": true,
+//            "processEnvironments": true
+//        },
+//        "TeX": {
+//            "extensions": ["color.js"]
+//        }
+//    }) + ");";
     fs.parentNode.insertBefore(script, fs);
     script = document.createElement("script");
     script.type = "text/javascript";
-    script.src  = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js";
+    // MathJax 2
+    script.src  = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS-MML_HTMLorMML";
+    // MathJax 3
+    // script.src  = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js";
     fs.parentNode.insertBefore(script, fs);
 }
 // Preload images


### PR DESCRIPTION
Hi Andrey,

As I understand it, MathJax3 sporadically fails to load extensions as needed. I don't know why.  This is contrary to the documentation. 

So in this patch, MathJax3 is configured to load the full package including all extensions. This seems to fix the problem.

But being afraid of that MathJax3 fails again in an unexpected way, I added back the MathJax2 configuration, but commented out. So we can quickly go back to MathJax2 if urgently necessary.

Thank you 
 