### PR TITLE
Vendor prefix all external JS deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ sage-root := $(shell [ -n "$$SAGE_ROOT" ] && echo "$$SAGE_ROOT" || sage --root |
 all-min-js = static/embedded_sagecell.js
 
 sagecell-css = static/sagecell.css
-all-min-css = build/all.min.css
+all-min-css = build/vendor/all.min.css
 embed-css = static/sagecell_embed.css
 
 tos-default = templates/tos_default.html
@@ -18,22 +18,23 @@ submodules:
 
 build:
 	-rm -r build
-	cp -a $(SAGE_VENV)/lib/python3.9/site-packages/notebook/static build
-	cp static/colorpicker/js/colorpicker.js build
+	mkdir -p build/vendor
+	cp -a $(SAGE_VENV)/lib/python3.9/site-packages/notebook/static build/vendor
+	cp static/colorpicker/js/colorpicker.js build/vendor
 	ln -sfn $(SAGE_VENV)/share/jupyter/nbextensions/jupyter_jsmol/jsmol static/jsmol
 	ln -sfn $(sage-root)/local/share/threejs-sage/r122 static/threejs
 	ln -sf $(sage-root)/local/share/jmol/appletweb/SageMenu.mnu static/SageMenu.mnu
-	cp static/jsmol/JSmol.min.nojq.js build/JSmol.js
-	wget -P build \
+	cp static/jsmol/JSmol.min.nojq.js build/vendor/JSmol.js
+	wget -P build/vendor \
 		https://raw.githubusercontent.com/sockjs/sockjs-client/master/dist/sockjs.js \
 		https://raw.githubusercontent.com/requirejs/domReady/latest/domReady.js \
 		https://raw.githubusercontent.com/requirejs/text/latest/text.js
-	python3 -c "from matplotlib.backends.backend_webagg_core import FigureManagerWebAgg; f = open('build/mpl.js', 'w'); f.write(FigureManagerWebAgg.get_javascript())"
+	python3 -c "from matplotlib.backends.backend_webagg_core import FigureManagerWebAgg; f = open('build/vendor/mpl.js', 'w'); f.write(FigureManagerWebAgg.get_javascript())"
 
 $(all-min-js): build $(all-min-css) js/*
 	# Host standalone jquery for compatibility with old instructions
 	cp build/components/jquery/jquery.min.js static
-	cp submodules/jquery-ui-touch-punch/jquery.ui.touch-punch.min.js build/jquery-ui-tp.js
+	cp submodules/jquery-ui-touch-punch/jquery.ui.touch-punch.min.js build/vendor/jquery-ui-tp.js
 	cp -a js/* build
 	cd build && r.js -o build.js
 	cp build/main_build.js $(all-min-js)

--- a/js/build.js
+++ b/js/build.js
@@ -1,7 +1,7 @@
 ({
     map: {
-        '*': { 'jquery': 'jquery-private' },
-        'jquery-private': { 'jquery': 'jquery' }
+        "*": { jquery: "jquery-private" },
+        "jquery-private": { jquery: "jquery" },
     },
     name: "main",
     out: "main_build.js",
@@ -9,21 +9,32 @@
     packages: [
         {
             name: "codemirror",
-            location: "components/codemirror",
-            main: "lib/codemirror"
-        }
+            location: "vendor/components/codemirror",
+            main: "lib/codemirror",
+        },
     ],
     paths: {
-        'es6-promise': 'components/es6-promise/promise',
-        "jquery" : "components/jquery/jquery.min",
-        "jquery-ui" : "components/jquery-ui/jquery-ui.min",
-        "moment" : "components/moment/min/moment.min",
-        "requireLib": "components/requirejs/require",
-        "underscore" : "components/underscore/underscore-min"
+        "es6-promise": "vendor/components/es6-promise/promise",
+        jquery: "vendor/components/jquery/jquery.min",
+        "jquery-ui": "vendor/components/jquery-ui/jquery-ui.min",
+        moment: "vendor/components/moment/min/moment.min",
+        requireLib: "vendor/components/requirejs/require",
+        underscore: "vendor/components/underscore/underscore-min",
+        sockjs: "vendor/sockjs",
+        "base/js/utils": "vendor/base/js/utils",
+        "base/js/namespace": "vendor/base/js/namespace",
+        "base/js/events": "vendor/base/js/events",
+        "services/kernels/kernel": "vendor/services/kernels/kernel",
+        "services/kernels/comm": "vendor/services/kernels/comm",
+        "services/kernels/serialize": "vendor/services/kernels/serialize",
+        "mpl": "vendor/mpl",
+        "text": "vendor/text",
+        "domReady": "vendor/domReady",
+        "colorpicker": "vendor/colorpicker",
+        "JSmol": "vendor/JSmol",
+        "all.min": "vendor/all.min",
     },
     waitSeconds: 70,
     wrap: true,
-    include: [
-        "requireLib"
-    ]
-})
+    include: ["requireLib"],
+});

--- a/js/utils.js
+++ b/js/utils.js
@@ -68,7 +68,7 @@ if (sagecell.root) {
             break;
         }
     }
-    if (root === "" || root === "/") {
+    if (!root || root === "/") {
         root = window.location.protocol + "//" + window.location.host + "/";
     }
 }


### PR DESCRIPTION
Copy all external JavaScript into `build/vendor` instead of directly into `build/`. This should make it easier to separate internal vs external dependencies during development.