### PR TITLE
Link sagecells from different `makeSagecell` calls

### DIFF
--- a/doc/embedding.rst
+++ b/doc/embedding.rst
@@ -248,6 +248,17 @@ will affect the execution of code from another cell:
 
 This option is ``false`` by default.
 
+If you would like to link cells created with different calls to ``makeSagecell``, you
+can use the ``linkKey`` attribute to specify a unique key. All cells initialized with
+the same ``linkKey`` will share a kernel.
+
+.. code-block:: javascript
+
+   { ..
+   linked: boolean,
+   linkKey: string
+   .. }
+
 Evaluate button text
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/js/cell.js
+++ b/js/cell.js
@@ -88,7 +88,7 @@ define([
                 throw "inputLocation must be unique if outputLocation is specified";
             }
             cellInfo.array = [];
-            if (args.linked) {
+            if (args.linked && k === undefined) {
                 args.autoeval = false;
                 k = sagecell.kernels.push(null) - 1;
             }

--- a/js/main.js
+++ b/js/main.js
@@ -103,6 +103,11 @@ require(["./sagecell", "./cell"], function (sagecell, cell) {
 
     sagecell._makeSagecell = function (args) {
         console.info("sagecell.makeSagecell called");
+        // If `args.linkKey` is set, we force the `linked` option to be true.
+        if (args.linkKey) {
+            args = Object.assign({}, args, { linked: true });
+        }
+
         var cellInfo = {};
         if (args.linked && args.linkKey) {
             cell.make(args, cellInfo, linkKeyToIndex(args.linkKey));


### PR DESCRIPTION
Fixes #546

This PR builds off of #550

It adds a `linkKey: string` attribute to the parameters of `makeSagecell`. All cells created with the same `linkKey` share a kernel. This option requires that `linked: true` is set (though it would be easy to automatically set `linked: true` if someone specifies a `linkKey`. I have no idea why someone wouldn't want that...).

An example is below. The divs `.link1` and `.link2` are linked to one kernel and the divs `.link3` and `.link4` are linked to a different kernel. They can all be linked to the same kernel by modifying `linkKey`.
```html
<!DOCTYPE HTML>
<html>
  <head>
    <meta charset="utf-8">
    <meta name="viewport" content="width=device-width">
    <title>SageMathCell</title>
    <script src="./main_build.js"></script>
    <script>
    // Make the div with id 'mycell' a Sage cell
    sagecell.makeSagecell({inputLocation:  '#mycell',
                           template:       sagecell.templates.minimal,
                           evalButtonText: 'Activate'});
    // Make *any* div with class 'compute' a Sage cell
    sagecell.makeSagecell({inputLocation: 'div.compute',
                           evalButtonText: 'Evaluate'});
    sagecell.makeSagecell({inputLocation: '.link1, .link2',
                           linked: true,
                           linkKey: "Y",
                           evalButtonText: 'Evaluate'});
    sagecell.makeSagecell({inputLocation: '.link3',
                           linked: true,
                           linkKey: "X",
                           evalButtonText: 'Evaluate'});
    sagecell.makeSagecell({inputLocation: '.link4',
                           linked: true,
                           linkKey: "X",
                           evalButtonText: 'Evaluate'});
    </script>
    <link property="sagecell-root" href="https://sagecell.sagemath.org" />
  </head>
  <body>
  <h1>Embedded Sage Cells</h1>

  <h2>Factorial</h2>
  Click the &ldquo;Activate&rdquo; button below to calculate factorials.
    <div id="mycell"><script type="text/x-sage">
@interact
def _(a=(1, 10)):
    print(factorial(a))
 </script>
</div>

<h2>Your own computations</h2>
Type your own Sage computation below and click &ldquo;Evaluate&rdquo;.
    <div class="compute"><script type="text/x-sage">plot(sin(x), (x, 0, 2*pi))</script></div>
    <div class="compute"><script type="text/x-sage">
@interact
def f(n=(0,10)):
    print(2^n)
</script></div>
    
  <div class="link1"><script type="text/x-sage">a=4
a
  </script></div>
  <div class="link2"><script type="text/x-sage">a
  </script></div>
  <div class="link3"><script type="text/x-sage">b=4
b
  </script></div>
  <div class="link4"><script type="text/x-sage">b
  </script></div>
  </body>
</html>
``` 