### PR TITLE
Add ability to silence terminal output

### DIFF
--- a/doc/js.rst
+++ b/doc/js.rst
@@ -33,6 +33,11 @@ ________________________________
    Built-in embedding templates. See :ref:`templates <Templates>` in the
    Embedding documentation for more information.
 
+.. _sagecell.quietMode:
+.. attribute:: sagecell.quietMode
+
+   Boolean. When set to true, only essential messages are printed to the console.
+
 .. _sagecell.init_embed:
 .. function:: sagecell.init(callback)
 

--- a/js/cell.js
+++ b/js/cell.js
@@ -17,6 +17,7 @@ import "colorpicker";
 import cell_body from "./cell_body.html";
 
 import { css } from "./css";
+import { console } from "./console";
 
 sagecell.modes = {
     sage: "python",

--- a/js/console.js
+++ b/js/console.js
@@ -1,0 +1,33 @@
+import sagecell from "./sagecell";
+
+export const origConsole = window.console;
+
+/**
+ * A replacement for window.console that suppresses logging based on `sagecell.quietMode`
+ */
+export const console = {
+    log(...args) {
+        if (sagecell.quietMode) {
+            return;
+        }
+        origConsole.log(...args);
+    },
+    info(...args) {
+        if (sagecell.quietMode) {
+            return;
+        }
+        origConsole.info(...args);
+    },
+    debug(...args) {
+        if (sagecell.quietMode) {
+            return;
+        }
+        origConsole.debug(...args);
+    },
+    error(...args) {
+        origConsole.error(...args);
+    },
+    warn(...args) {
+        origConsole.warn(...args);
+    },
+};

--- a/js/main.js
+++ b/js/main.js
@@ -6,6 +6,7 @@ import "./jquery-global";
 // TODO: finish implementing our own stats service that handles,
 //       the phone apps, for example.
 import { _gaq } from "./gaq";
+import { console } from "./console";
 _gaq.push(["sagecell._setAccount", "UA-29124745-1"]);
 _gaq.push(["sagecell._setDomainName", "sagemath.org"]);
 _gaq.push(["sagecell._trackPageview"]);
@@ -88,6 +89,7 @@ Object.assign(sagecell, {
         }
     },
     _initPromise: makeResolvablePromise(),
+    quietMode: false,
 });
 
 // Purely for backwards compatibility

--- a/js/multisockjs.js
+++ b/js/multisockjs.js
@@ -1,6 +1,7 @@
 import { URLs } from "./urls";
 import SockJS from "sockjs-client";
 import utils from "./utils";
+import { console } from "./console";
 
 export function MultiSockJS(url, prefix) {
     console.debug(

--- a/js/session.js
+++ b/js/session.js
@@ -11,6 +11,7 @@ import utils from "./utils";
 import widgets from "./widgets";
 
 import { URLs } from "./urls";
+import { console } from "./console";
 
 Kernel.Kernel.prototype.kill = function () {
     utils.sendRequest("DELETE", this.kernel_url);

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 import utils from "base/js/utils";
 import { URLs } from "./urls";
+import { console } from "./console";
 
 /* IPython url_join_encode and url_path_join is used in the cell server with URLs with hostnames, so we make it handle those correctly
     this is a temporary kludge.  A much better fix would be to introduce a kernel_base_url parameter in the kernel

--- a/js/widgets.js
+++ b/js/widgets.js
@@ -3,6 +3,7 @@ import utils from "./utils";
 
 // Creates global namespace
 import "mpl";
+import { console } from "./console";
 
 export const widgets = {
     Graphics: function (session) {


### PR DESCRIPTION
A lot of the terminal output seems unnecessary (and clutters the console) in a larger project. This is especially true when `sagecell.makeCell` is being called multiple times.

This PR adds a flag, `sagecell.quietMode` to disable non-essential output. It defaults to `false`, which doesn't change current behavior, but I would advocate for it defaulting to `true`.