### PR TITLE
Add aria-label to textarea element for accessibility

### DIFF
--- a/js/cell_body.html
+++ b/js/cell_body.html
@@ -7,6 +7,7 @@
             autocorrect="off"
             inputmode="verbatim"
             x-inputmode="verbatim"
+            aria-label="sagecell-textarea"
         ></textarea>
     </div>
     <!-- Explicitly set a button type other than 'submit' so it doesn't submit a form -->


### PR DESCRIPTION
Using the [WAVE accessibility tool](https://wave.webaim.org/), pages with embedded sage cells have accessibility errors because the `<textarea>` element does not contain a label.   Adding an attribute `aria-label="..."` should fix this.

I *think* I put this in the right place, but if it should go somewhere else, please let me know (I'm not familiar with the codebase here).