### PR TITLE
add aria-label to codemirror-created textareas

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -231,6 +231,7 @@ function render(editorType, inputLocation, collapse) {
             readOnly: readOnly,
             foldGutter: true,
             gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"],
+            screenReaderLabel: "Sagecell editor",
             extraKeys: {
                 Tab: function (cm) {
                     var cur = cm.getCursor();


### PR DESCRIPTION
Thanks for the recent merge of #585.  That addressed only one of the textareas created by the code, it appears.  This should fix the other one (we recently fixed a similar issue in Runestone using the same method as this).